### PR TITLE
Banned cross-domain redirects after sign in

### DIFF
--- a/lib/foyer/omniauth_callbacks_controller.rb
+++ b/lib/foyer/omniauth_callbacks_controller.rb
@@ -8,7 +8,8 @@ module Foyer
 
     protected
     def after_sign_in_path
-      origin || root_path
+      return origin if origin.to_s.match(/^\//) || origin.to_s.match(%r{^#{request.scheme}://#{request.host}})
+      root_path
     end
 
     private


### PR DESCRIPTION
Fixes #7. It checks that URL supplied origin exists on the same domain foyer operates on.